### PR TITLE
Update number.py to fix illegal default value (fixes #3)

### DIFF
--- a/homie/number.py
+++ b/homie/number.py
@@ -57,7 +57,7 @@ PLATFORM_SCHEMA = entity_base.SCHEMA_BASE.extend(
         vol.Optional(CONF_MIN): vol.Coerce(float),
         vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
         vol.Optional(CONF_STEP): vol.All(vol.Coerce(float), vol.Range(min=1e-3)),
-        vol.Optional(CONF_MODE, default=number.MODE_AUTO): vol.All(
+        vol.Optional(CONF_MODE, default=number.NumberMode.AUTO): vol.All(
             vol.Lower, vol.In(["auto", "slider", "box"])
         ),
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,


### PR DESCRIPTION
This issue should fix #3 

I finally found some time for testing your implementation. Looks really nice already!

As soon as I added the integration, Home Assistant showed an error in my logs saying that the [number component](https://github.com/home-assistant/core/blob/dev/homeassistant/components/number/__init__.py#L47) does not have a property called `MODE_AUTO`. 

When digging into the code I noticed that there was a faulty usage for the default value of the mode. I changed it (and tested it locally) and the error is gone now!